### PR TITLE
Response headers and helpful messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,27 +47,40 @@ def index():
 def api():
 	id = request.args.get('id', 0, type=str)
 	print 'request for id', id
-	res = data[id]
-	print 'res', res
-	return jsonify(result=res)
+	try:
+		res = data[id]
+		response = jsonify(result=res)
+		response.headers['Access-Control-Allow-Origin'] = '*'
+		return response
+	except KeyError:
+		print 'Invalid Key'
+		response = jsonify(result='key not found')
+		response.headers['Access-Control-Allow-Origin'] = '*'
+		return response
 
 # Given time, returns all stations where train stops at that time
 @app.route('/times')
 def times():
-	hour = request.args.get('hour', 0, type=str)
-	minute = request.args.get('minute', 0, type=str)
-	# print 'request for hour and min', hour, minute
-	i = 0
-	results = []
-	for key in data:
-		arrivals = data[key]['arrivals']
-		for arrival in arrivals:
-			a = arrival.split(":")
-			if a[0] == hour and a[1] == minute:
-				result = {'id': key, 'name': data[key]['name'], 'lat': data[key]['lat'], 'lon': data[key]['lon'], 'arrival': arrival}
-				results.append(result)
-	return jsonify(result=results)
-
+	if len(request.args) != 2:
+		response = jsonify(result='must specify hour and minute')
+		response.headers['Access-Control-Allow-Origin'] = '*'
+		return response
+	else:
+		hour = request.args.get('hour', 0, type=str)
+		minute = request.args.get('minute', 0, type=str)
+		# print 'request for hour and min', hour, minute
+		i = 0
+		results = []
+		for key in data:
+			arrivals = data[key]['arrivals']
+			for arrival in arrivals:
+				a = arrival.split(":")
+				if a[0] == hour and a[1] == minute:
+					result = {'id': key, 'name': data[key]['name'], 'lat': data[key]['lat'], 'lon': data[key]['lon'], 'arrival': arrival}
+					results.append(result)
+		response = jsonify(result=results)
+		response.headers['Access-Control-Allow-Origin'] = '*'
+		return response
 
 # Provide ids for all stations
 @app.route('/stations')
@@ -76,15 +89,22 @@ def stations():
 	for id in ids:
 		station = {'id': id, 'name': data[id]['name']} 
 		stations.append(station)
-		
-	return jsonify(result=stations[1:])
+	response = jsonify(result=stations[1:])
+	response.headers['Access-Control-Allow-Origin'] = '*'
+	return response
 
 @app.route('/stop')
 def station():
-	req = request.args.get('id', 0, type=str)
-	res = {'name': data[req]['name'], 'lat': data[req]['lat'], 'lon': data[req]['lon']}
-
-	return jsonify(result=res)
+	try:
+		req = request.args.get('id', 0, type=str)
+		res = {'name': data[req]['name'], 'lat': data[req]['lat'], 'lon': data[req]['lon']}
+		response = jsonify(result=res)
+		response.headers['Access-Control-Allow-Origin'] = '*'
+		return response
+	except KeyError:
+		response = jsonify(result='key not found')
+		response.headers['Access-Control-Allow-Origin'] = '*'
+		return response
 
 if __name__ == "__main__":
 	app.run()


### PR DESCRIPTION
The JSON objects returned by `jsonify` did not specify a CORS response
header, so AJAX requests to the API were being shut down for security
reasons. This update adds the CORS-friendly header to the response
object returned from `jsonify` and then returns that update object.

Also there were some 500 errors and empty responses generated if you hit
an endpoint without the proper parameters. This update also adds some
helpful messages to API requests that don't have the necessary params.
